### PR TITLE
Past launches page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
-// src/App.tsx
 import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import UpcomingLaunches from './pages/UpcomingLaunches';
+import PastLaunches from './pages/PastLaunches';
 import Layout from './components/Layout/Layout';
 
 const App: React.FC = () => {
@@ -10,6 +10,7 @@ const App: React.FC = () => {
       <Layout>
         <Routes>
           <Route path="/upcoming-launches" element={<UpcomingLaunches />} />
+          <Route path="/past-launches" element={<PastLaunches />} />
         </Routes>
       </Layout>
     </Router>

--- a/src/pages/PastLaunches.tsx
+++ b/src/pages/PastLaunches.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Grid, Box } from '@chakra-ui/react';
+import LaunchCard from '../components/LaunchCard/LaunchCard';
+import { useGetPastLaunchesQuery } from '../services/spaceXApi';
+import Spinner from '../components/Spinner/Spinner';
+import ErrorMessage from '../components/ErrorMessage/ErrorMessage';
+
+const PastLaunches: React.FC = () => {
+  const { data: launches, error, isLoading, refetch } = useGetPastLaunchesQuery();
+
+  if (isLoading) {
+    return (
+      <Box display="flex" alignItems="center" justifyContent="center" minH="100vh">
+        <Spinner />
+      </Box>
+    )
+  }
+
+  if (error) {
+    return (
+      <Box display="flex" flexDirection="column" alignItems="center" justifyContent="center" minH="100vh">
+        <ErrorMessage message="Error loading past launches" onRetry={refetch} />
+      </Box>
+    )
+  };
+
+  return (
+    <Grid templateColumns="repeat(auto-fill, minmax(280px, 1fr))" gap={4}>
+      {launches?.map((launch) => (
+        <LaunchCard
+          key={launch.id}
+          id={launch.id}
+          name={launch.name}
+          date={launch.date_utc}
+          location={launch.launchpad}
+          success={launch.success}
+          imageUrl={launch.links?.patch?.small || ''}
+        />
+      ))}
+    </Grid>
+  );
+};
+
+export default PastLaunches;


### PR DESCRIPTION
This PR includes:

- Past launches page
- Add past launches route

**Preview**

**Success state**

<img width="1510" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/beee41f5-990e-4cc8-9d9f-d96848c494cd">


**Loading state**

<img width="1511" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/73a728a6-9a6a-489a-9b97-8960b0fcf8bb">


**Error state**

<img width="1501" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/fe8d4b27-e17e-453a-ae2f-0fc062aff23b">